### PR TITLE
Add foundational Libran translation and synthesis toolkit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.so
+*.egg-info/
+.build/
+.pytest_cache/
+.dist/
+dist/
+build/
+.eggs/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,45 @@
 # english-to-libran-text-to-voice
-Application used to convert English paragrapphs into a fictional language
+
+A Python toolkit that transforms English paragraphs into a fictional Libran
+language and optionally generates a simple spoken rendition. The audio output is
+based on deterministic sine-wave synthesis which keeps the project lightweight
+and dependency free.
+
+## Features
+
+- Normalizes and translates English text into a consistent Libran dialect
+- Deterministic pseudo-word generation for unknown vocabulary
+- Simple sine-wave speech synthesizer that outputs standard PCM wave files
+- Command line interface with optional audio export
+
+## Getting started
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[dev]
+```
+
+Run the unit test suite with:
+
+```bash
+pytest
+```
+
+## Command line usage
+
+Translate text provided directly on the command line:
+
+```bash
+libran-voice --text "Hello world!"
+```
+
+Read from a file and export audio:
+
+```bash
+libran-voice --input-file paragraph.txt --audio-output output.wav
+```
+
+You can adjust synthesis parameters such as the symbol duration and sample rate
+via command-line flags. The generated audio is intentionally stylized and does
+not represent a real language; it serves as a placeholder for early prototyping.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "english-to-libran-voice"
+version = "0.1.0"
+description = "Convert English text into a fictional Libran language and generate simple audio"
+authors = [{name = "Project Maintainers"}]
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = []
+
+[project.optional-dependencies]
+dev = ["pytest>=7.4"]
+
+[project.scripts]
+libran-voice = "english_to_libran_voice.cli:main"
+
+[tool.pytest.ini_options]
+addopts = "-ra"
+testpaths = ["tests"]

--- a/src/english_to_libran_voice/__init__.py
+++ b/src/english_to_libran_voice/__init__.py
@@ -1,0 +1,6 @@
+"""Top-level package for the English to Libran text to voice project."""
+
+from .converter import english_to_libran, normalize_text
+from .synthesizer import LibranSynthesizer
+
+__all__ = ["english_to_libran", "normalize_text", "LibranSynthesizer"]

--- a/src/english_to_libran_voice/cli.py
+++ b/src/english_to_libran_voice/cli.py
@@ -1,0 +1,55 @@
+"""Command line interface for the Libran text to voice toolkit."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Optional
+
+from .converter import english_to_libran
+from .synthesizer import LibranSynthesizer
+
+
+def _read_text(args: argparse.Namespace) -> str:
+    if args.text:
+        return args.text
+    if args.input_file:
+        return Path(args.input_file).read_text(encoding="utf-8")
+    return sys.stdin.read()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Convert English text into Libran and optionally synthesize audio.")
+    parser.add_argument("--text", help="Text to convert. If omitted a file or stdin is used.")
+    parser.add_argument("--input-file", help="Read English text from a file.")
+    parser.add_argument("--audio-output", help="Write a synthesized wave file to this path.")
+    parser.add_argument(
+        "--symbol-duration",
+        type=float,
+        default=0.12,
+        help="Duration of each synthesized symbol in seconds (default: 0.12)",
+    )
+    parser.add_argument(
+        "--sample-rate",
+        type=int,
+        default=22_050,
+        help="Sample rate for the synthesized audio (default: 22050)",
+    )
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    english_text = _read_text(args)
+    libran_text = english_to_libran(english_text)
+    print(libran_text)
+
+    if args.audio_output:
+        synthesizer = LibranSynthesizer(sample_rate=args.sample_rate, symbol_duration=args.symbol_duration)
+        synthesizer.save(libran_text, args.audio_output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/english_to_libran_voice/converter.py
+++ b/src/english_to_libran_voice/converter.py
@@ -1,0 +1,125 @@
+"""Utilities to translate English text into the fictional Libran language."""
+from __future__ import annotations
+
+import re
+from typing import Dict, Iterable, List
+
+_TOKEN_RE = re.compile(r"[A-Za-z0-9']+|[^A-Za-z0-9']")
+
+DEFAULT_DICTIONARY: Dict[str, str] = {
+    "hello": "valori",
+    "world": "zenith",
+    "language": "oratil",
+    "voice": "sonari",
+    "story": "mythra",
+    "friend": "kaleth",
+    "journey": "sereth",
+    "star": "lyr",
+    "light": "phora",
+    "shadow": "umbra",
+}
+
+_SYLLABLES: List[str] = [
+    "li",
+    "ra",
+    "ba",
+    "no",
+    "ka",
+    "se",
+    "tu",
+    "ven",
+    "zor",
+    "mi",
+    "pha",
+    "el",
+]
+
+VOWEL_SUFFIXES = {
+    "a": "ra",
+    "e": "ri",
+    "i": "la",
+    "o": "no",
+    "u": "ma",
+}
+
+
+def normalize_text(text: str) -> str:
+    """Return a normalized representation of *text*.
+
+    The transformation keeps alphanumeric characters and apostrophes, removes
+    other punctuation, collapses multiple spaces and converts the text to lower
+    case. The helper is primarily meant to improve matching against the
+    ``DEFAULT_DICTIONARY`` and to aid deterministic pseudo-word generation.
+    """
+
+    lowered = text.lower()
+    cleaned = re.sub(r"[^a-z0-9'\s]+", " ", lowered)
+    collapsed = re.sub(r"\s+", " ", cleaned).strip()
+    return collapsed
+
+
+def _procedural_word(word: str, syllables: Iterable[str] = _SYLLABLES) -> str:
+    """Create a deterministic pseudo-word for *word*.
+
+    The algorithm walks through the characters of ``word`` and uses their code
+    points and positions to index into the ``syllables`` list. The result is a
+    pronounceable string that is stable between runs which helps keep tests
+    deterministic.
+    """
+
+    if not word:
+        return ""
+
+    pieces: List[str] = []
+    syllable_list = list(syllables)
+    if not syllable_list:
+        raise ValueError("syllables must not be empty")
+
+    for index, character in enumerate(word):
+        base = ord(character)
+        syllable_index = (base + index) % len(syllable_list)
+        pieces.append(syllable_list[syllable_index])
+
+    if word[-1] in VOWEL_SUFFIXES:
+        pieces.append(VOWEL_SUFFIXES[word[-1]])
+
+    return "".join(pieces)
+
+
+def _apply_casing(source: str, translated: str) -> str:
+    """Adjust *translated* so its casing matches *source*."""
+
+    if not source:
+        return translated
+    if source.isupper():
+        return translated.upper()
+    if source[0].isupper():
+        return translated.capitalize()
+    return translated
+
+
+def english_to_libran(text: str, dictionary: Dict[str, str] | None = None) -> str:
+    """Translate *text* into Libran using ``dictionary`` when possible."""
+
+    mapping = {**DEFAULT_DICTIONARY}
+    if dictionary:
+        mapping.update({k.lower(): v for k, v in dictionary.items()})
+
+    tokens = _TOKEN_RE.findall(text)
+    translated_tokens: List[str] = []
+    for token in tokens:
+        if token.isalpha() or token.replace("'", "").isalnum():
+            lookup_key = token.lower()
+            translated = mapping.get(lookup_key)
+            if not translated:
+                normalized = normalize_text(token)
+                translated = mapping.get(normalized)
+            if not translated:
+                translated = _procedural_word(normalize_text(token))
+            translated_tokens.append(_apply_casing(token, translated))
+        else:
+            translated_tokens.append(token)
+    return "".join(translated_tokens)
+
+
+__all__ = ["english_to_libran", "normalize_text", "DEFAULT_DICTIONARY"]

--- a/src/english_to_libran_voice/synthesizer.py
+++ b/src/english_to_libran_voice/synthesizer.py
@@ -1,0 +1,77 @@
+"""Generate simple speech-like audio for Libran text."""
+from __future__ import annotations
+
+import io
+import math
+import struct
+import wave
+from dataclasses import dataclass
+
+
+def _char_frequency(character: str) -> float:
+    """Return a pseudo phoneme frequency for *character*."""
+
+    base_map = {
+        "a": 440.0,
+        "e": 493.88,
+        "i": 523.25,
+        "o": 587.33,
+        "u": 659.25,
+        "l": 392.0,
+        "r": 415.3,
+        "n": 349.23,
+        "s": 329.63,
+    }
+    if character.lower() in base_map:
+        return base_map[character.lower()]
+    if character.isalpha():
+        offset = (ord(character.lower()) - ord("a")) % 26
+        return 300.0 + offset * 12.5
+    if character.isdigit():
+        return 250.0 + int(character) * 20.0
+    return 0.0
+
+
+@dataclass
+class LibranSynthesizer:
+    """Convert Libran text into a waveform using sine synthesis."""
+
+    sample_rate: int = 22_050
+    symbol_duration: float = 0.12
+    amplitude: int = 16_000
+
+    def synthesize(self, text: str) -> bytes:
+        """Return a mono wave file stored in memory for ``text``."""
+
+        buffer = io.BytesIO()
+        with wave.open(buffer, "wb") as wav_file:
+            wav_file.setnchannels(1)
+            wav_file.setsampwidth(2)
+            wav_file.setframerate(self.sample_rate)
+            frames = self._frames_for_text(text)
+            wav_file.writeframes(frames)
+        return buffer.getvalue()
+
+    def save(self, text: str, path: str) -> None:
+        """Write the synthesized Libran speech for ``text`` to ``path``."""
+
+        audio = self.synthesize(text)
+        with open(path, "wb") as handle:
+            handle.write(audio)
+
+    def _frames_for_text(self, text: str) -> bytes:
+        frames = bytearray()
+        samples_per_symbol = int(self.sample_rate * self.symbol_duration)
+        for character in text:
+            frequency = _char_frequency(character)
+            if frequency == 0.0:
+                frames.extend(b"\x00\x00" * samples_per_symbol)
+                continue
+            for index in range(samples_per_symbol):
+                angle = 2.0 * math.pi * frequency * index / self.sample_rate
+                sample = int(self.amplitude * math.sin(angle))
+                frames.extend(struct.pack("<h", sample))
+        return bytes(frames)
+
+
+__all__ = ["LibranSynthesizer"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,0 +1,26 @@
+from english_to_libran_voice.converter import english_to_libran, normalize_text
+
+
+def test_normalize_text_strips_punctuation_and_lowercases():
+    assert normalize_text("Hello, World!!") == "hello world"
+
+
+def test_english_to_libran_uses_default_dictionary():
+    text = "Hello world!"
+    result = english_to_libran(text)
+    assert "Valori" in result
+    assert "zenith" in result.lower()
+
+
+def test_english_to_libran_is_deterministic_for_unknown_words():
+    first = english_to_libran("mystery")
+    second = english_to_libran("Mystery")
+    assert first.lower() == second.lower()
+
+
+def test_custom_dictionary_is_respected():
+    custom = {"friend": "allya"}
+    result = english_to_libran("Friend")
+    assert "Kaleth" in result
+    override = english_to_libran("Friend", dictionary=custom)
+    assert "Allya" in override

--- a/tests/test_synthesizer.py
+++ b/tests/test_synthesizer.py
@@ -1,0 +1,12 @@
+from english_to_libran_voice.synthesizer import LibranSynthesizer
+
+
+def test_synthesize_produces_wave_bytes(tmp_path):
+    synthesizer = LibranSynthesizer(symbol_duration=0.01)
+    audio_bytes = synthesizer.synthesize("lira")
+    assert audio_bytes.startswith(b"RIFF")
+
+    path = tmp_path / "sample.wav"
+    synthesizer.save("lira", path)
+    assert path.exists()
+    assert path.read_bytes().startswith(b"RIFF")


### PR DESCRIPTION
## Summary
- introduce a Python package for converting English text into a fictional Libran dialect
- add a sine-wave based synthesizer and CLI for generating Libran audio previews
- configure packaging metadata, ignore rules, and author unit tests for conversion and synthesis helpers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce87f9ed48832990750f7fd75ba714