### PR TITLE
Honor dump csv option in CLI build command

### DIFF
--- a/tools/dict_importer/README.md
+++ b/tools/dict_importer/README.md
@@ -39,6 +39,11 @@ python -m dict_importer.cli build \
     --dump-csv build/ALL_ROWS.csv
 ```
 
+When `--dump-csv` is provided, the CLI copies the generated `ALL_ROWS.csv`
+report into the requested location after the build finishes. This makes it easy
+to archive or inspect the complete row export without digging into the build
+output directory.
+
 ### Testing PDF Parsing
 
 ```bash

--- a/tools/dict_importer/dict_importer/cli.py
+++ b/tools/dict_importer/dict_importer/cli.py
@@ -1,8 +1,10 @@
 """CLI interface for dictionary importer."""
 
-import click
+import shutil
 from pathlib import Path
-from typing import Set, Optional
+from typing import Optional
+
+import click
 
 from .parse_tables import parse_pdf_pages
 from .build_dicts import build_dictionaries
@@ -71,6 +73,19 @@ def build(pdf: str, out: str, support: Optional[str] = None,
         # Build dictionaries
         click.echo("Building dictionaries...")
         build_result = build_dictionaries(parsed_pages, output_dir, exclude_terms)
+
+        if dump_csv:
+            dump_path = Path(dump_csv)
+            dump_path.parent.mkdir(parents=True, exist_ok=True)
+            source_csv = output_dir / "ALL_ROWS.csv"
+            if source_csv.exists():
+                shutil.copy2(source_csv, dump_path)
+                click.echo(f"ALL_ROWS.csv copied to: {dump_path}")
+            else:
+                click.echo(
+                    "Warning: ALL_ROWS.csv was not generated; cannot copy to dump location.",
+                    err=True,
+                )
         
         # Print summary
         click.echo("\nBuild completed successfully!")

--- a/tools/dict_importer/tests/test_cli.py
+++ b/tools/dict_importer/tests/test_cli.py
@@ -1,0 +1,55 @@
+"""Tests for the dict_importer CLI commands."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from click.testing import CliRunner
+
+from dict_importer.cli import cli
+
+
+def test_build_command_dump_csv(tmp_path, monkeypatch):
+    """The build command should copy ALL_ROWS.csv to the requested dump path."""
+
+    pdf_path = tmp_path / "source.pdf"
+    pdf_path.write_bytes(b"%PDF-1.4")
+    output_dir = tmp_path / "output"
+    requested_dump = tmp_path / "exports" / "all_rows.csv"
+
+    def fake_parse_pdf_pages(path):
+        assert Path(path) == pdf_path
+        return ["dummy-page"]
+
+    def fake_build_dictionaries(parsed_pages, destination, exclude_terms):
+        assert parsed_pages == ["dummy-page"]
+        destination.mkdir(parents=True, exist_ok=True)
+        (destination / "ALL_ROWS.csv").write_text("English,Ancient\nfoo,bar\n")
+        return SimpleNamespace(
+            ancient_entries={"foo": "bar"},
+            modern_entries={"foo": "modern"},
+            excluded_entries=[],
+            variant_entries=[],
+        )
+
+    monkeypatch.setattr("dict_importer.cli.parse_pdf_pages", fake_parse_pdf_pages)
+    monkeypatch.setattr(
+        "dict_importer.cli.build_dictionaries", fake_build_dictionaries
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "build",
+            "--pdf",
+            str(pdf_path),
+            "--out",
+            str(output_dir),
+            "--dump-csv",
+            str(requested_dump),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert requested_dump.exists()
+    assert requested_dump.read_text() == "English,Ancient\nfoo,bar\n"


### PR DESCRIPTION
## Summary
- ensure the `--dump-csv` CLI option copies the generated ALL_ROWS.csv report to the requested location after the build completes
- add a CLI test that simulates the build path and verifies the CSV is produced at the dump target
- document the finalized dump flag behavior in the README advanced usage section

## Testing
- `PYTHONPATH=. pytest` *(fails: missing optional dependency `pydantic` in the execution environment)*
- `pip install -e .[dev]` *(fails: network proxy prevents downloading build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68cea335330883299f4657089263e72b