### PR TITLE
Add Node test suite for translator and API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules/
 .next/
 out/
 dist/
+dist-test/
 build/
 
 # Environment variables

--- a/lib/translator/index.ts
+++ b/lib/translator/index.ts
@@ -13,6 +13,10 @@ interface Dictionary {
   [key: string]: string;
 }
 
+export interface TranslateOptions {
+  dictionary?: Dictionary;
+}
+
 // Load dictionary from file
 function loadDictionary(variant: Variant): Dictionary {
   const filePath = path.join(process.cwd(), 'lib', 'translator', 'dictionaries', `${variant}.json`);
@@ -114,8 +118,8 @@ function fixSpacing(tokens: Array<{ type: string, value: string, original: strin
   return result;
 }
 
-export function translate(text: string, variant: Variant): TranslationResult {
-  const dictionary = loadDictionary(variant);
+export function translate(text: string, variant: Variant, options: TranslateOptions = {}): TranslationResult {
+  const dictionary = options.dictionary ?? loadDictionary(variant);
   const tokens = tokenize(text);
   const translatedTokens = [];
   let translatedWordCount = 0;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,11 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "clean:test": "node -e \"require('fs').rmSync('dist-test', { recursive: true, force: true });\"",
+    "build:test": "npm run clean:test && tsc -p tsconfig.test.json",
+    "test:run": "node --test --test-reporter=spec \"dist-test/**/*.test.js\"",
+    "test": "npm run build:test && npm run test:run"
   },
   "dependencies": {
     "lucide-react": "^0.544.0",

--- a/test/integration/translate-api.integration.test.ts
+++ b/test/integration/translate-api.integration.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, before } from 'node:test'
+import assert from 'node:assert/strict'
+
+let POST: (request: any) => Promise<Response>
+
+describe('POST /api/translate', () => {
+  before(async () => {
+    const Module = require('module')
+    const originalLoad = Module._load
+
+    Module._load = (request: string, parent: any, isMain: boolean) => {
+      if (request === 'next/server') {
+        return {
+          NextResponse: class extends Response {
+            static json(data: any, init?: { status?: number }) {
+              return new Response(JSON.stringify(data), {
+                status: init?.status ?? 200,
+                headers: { 'content-type': 'application/json' }
+              })
+            }
+          }
+        }
+      }
+
+      if (request === '@/lib/translator') {
+        const translatorPath = `${process.cwd()}/dist-test/lib/translator/index.js`
+        return originalLoad(translatorPath, parent, isMain)
+      }
+
+      return originalLoad(request, parent, isMain)
+    }
+
+    const route = await import('../../app/api/translate/route')
+    POST = route.POST
+    Module._load = originalLoad
+  })
+
+  it('returns a successful translation response', async () => {
+    const request = {
+      json: async () => ({ text: 'Hello world', variant: 'ancient' })
+    } as any
+
+    const response = await POST(request)
+    assert.equal(response.status, 200)
+
+    const body = await response.json()
+    assert.equal(body.libran, 'Salaam dunya')
+    assert.equal(body.confidence, 1)
+    assert.equal(body.wordCount, 2)
+    assert.equal(body.variant, 'ancient')
+  })
+
+  it('rejects invalid payloads', async () => {
+    const request = {
+      json: async () => ({ text: 123 })
+    } as any
+
+    const response = await POST(request)
+    assert.equal(response.status, 400)
+
+    const body = await response.json()
+    assert.equal(body.error, 'Text is required and must be a string')
+  })
+
+  it('enforces allowed translation variants', async () => {
+    const request = {
+      json: async () => ({ text: 'Hello', variant: 'future' })
+    } as any
+
+    const response = await POST(request)
+    assert.equal(response.status, 400)
+
+    const body = await response.json()
+    assert.equal(body.error, 'Variant must be either "ancient" or "modern"')
+  })
+})

--- a/test/integration/translate.integration.test.ts
+++ b/test/integration/translate.integration.test.ts
@@ -1,0 +1,29 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { translate } from '../../lib/translator'
+
+describe('translate (integration)', () => {
+  it('translates text using bundled dictionaries', () => {
+    const result = translate('Hello, world!', 'ancient')
+
+    assert.equal(result.libran, 'Salaam, dunya!')
+    assert.equal(result.confidence, 1)
+    assert.equal(result.wordCount, 2)
+  })
+
+  it('retains unknown words and calculates confidence', () => {
+    const result = translate('Hello unknown magic', 'ancient')
+
+    assert.equal(result.libran, 'Salaam unknown sihr')
+    assert.equal(result.wordCount, 3)
+    assert.equal(result.confidence, 2 / 3)
+  })
+
+  it('preserves spacing and punctuation in longer phrases', () => {
+    const text = 'The sky, the earth, and the sea.'
+    const result = translate(text, 'ancient')
+
+    assert.equal(result.libran, 'Al samaa, al ard, wa al bahr.')
+  })
+})

--- a/test/types/shims.d.ts
+++ b/test/types/shims.d.ts
@@ -1,0 +1,52 @@
+declare module 'fs' {
+  export function readFileSync(path: string, options?: { encoding?: string } | string): string
+  const fsDefault: {
+    readFileSync: typeof readFileSync
+  }
+  export default fsDefault
+}
+
+declare module 'path' {
+  export function join(...paths: string[]): string
+  const pathDefault: {
+    join: typeof join
+  }
+  export default pathDefault
+}
+
+declare module 'node:assert/strict' {
+  import assert = require('assert')
+  export = assert
+}
+
+declare module 'node:test' {
+  export function describe(name: string, fn: () => void): void
+  export function it(name: string, fn: () => any): void
+  export function before(fn: () => any): void
+  export function test(name: string, fn: (...args: any[]) => any): void
+}
+
+declare module 'module' {
+  interface ModuleType {
+    _load(request: string, parent: any, isMain: boolean): any
+    _resolveFilename(request: string, parent: any, isMain: boolean): string
+    _cache: Record<string, any>
+  }
+
+  const Module: ModuleType
+  export = Module
+}
+
+declare function require(moduleName: string): any
+
+declare module 'next/server' {
+  export class NextRequest extends Request {}
+  export class NextResponse extends Response {
+    static json(data: any, init?: { status?: number }): NextResponse
+  }
+}
+
+declare const process: {
+  cwd(): string
+  env: Record<string, string | undefined>
+}

--- a/test/unit/tokenizer.test.ts
+++ b/test/unit/tokenizer.test.ts
@@ -1,0 +1,47 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { tokenizeText, joinTokens, preserveCase } from '../../lib/translator/tokenizer'
+
+describe('tokenizeText', () => {
+  it('splits words, punctuation, whitespace, and numbers', () => {
+    const tokens = tokenizeText('Hello, world! 42 times')
+
+    assert.equal(tokens.length, 9)
+    assert.deepEqual(
+      tokens.map(token => token.type),
+      ['word', 'punctuation', 'whitespace', 'word', 'punctuation', 'whitespace', 'number', 'whitespace', 'word']
+    )
+
+    assert.equal(tokens[0].value, 'hello')
+    assert.equal(tokens[0].original, 'Hello')
+    assert.equal(tokens[3].value, 'world')
+    assert.equal(tokens[6].value, '42')
+    assert.equal(tokens[8].value, 'times')
+  })
+})
+
+describe('joinTokens', () => {
+  it('reconstructs text from translated values when available', () => {
+    const tokens = tokenizeText('Hello world')
+    tokens[0].translatedValue = 'salaam'
+    tokens[2].translatedValue = 'dunya'
+
+    const result = joinTokens(tokens)
+    assert.equal(result, 'salaam dunya')
+  })
+})
+
+describe('preserveCase', () => {
+  it('maintains uppercase words', () => {
+    assert.equal(preserveCase('HELLO', 'salaam'), 'SALAAM')
+  })
+
+  it('maintains lowercase words', () => {
+    assert.equal(preserveCase('hello', 'salaam'), 'salaam')
+  })
+
+  it('maintains capitalized words', () => {
+    assert.equal(preserveCase('Hello', 'salaam'), 'Salaam')
+  })
+})

--- a/test/unit/translate-options.test.ts
+++ b/test/unit/translate-options.test.ts
@@ -1,0 +1,40 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { translate } from '../../lib/translator'
+
+describe('translate with custom dictionary', () => {
+  it('uses the provided dictionary when supplied', () => {
+    const result = translate('Hello friend', 'ancient', {
+      dictionary: {
+        hello: 'salaam',
+        friend: 'sadiq'
+      }
+    })
+
+    assert.equal(result.libran, 'Salaam sadiq')
+    assert.equal(result.confidence, 1)
+    assert.equal(result.wordCount, 2)
+  })
+
+  it('falls back to stemmed forms for simple suffixes', () => {
+    const result = translate('Walks', 'ancient', {
+      dictionary: {
+        walk: 'tor'
+      }
+    })
+
+    assert.equal(result.libran, 'Tor')
+    assert.equal(result.confidence, 1)
+  })
+
+  it('applies modern sound shifts to -or endings', () => {
+    const result = translate('Valor', 'modern', {
+      dictionary: {
+        valor: 'valor'
+      }
+    })
+
+    assert.equal(result.libran, 'Vala')
+  })
+})

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "rootDir": ".",
+    "outDir": "./dist-test",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "typeRoots": ["./test/types"],
+    "lib": ["es2020", "dom"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": [
+    "test/**/*.ts",
+    "lib/translator/**/*.ts",
+    "app/api/translate/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- allow the translator to accept a custom dictionary so translation behaviour can be unit tested
- configure a Node test harness with TypeScript compilation, custom shims, and npm scripts
- add unit and integration tests covering tokenizer utilities, translation logic, and the translate API route

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ceb54ee7708329a54bd5bd2675b181