### PR TITLE
Improve logger fallbacks when pino transport is unavailable

### DIFF
--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,6 +1,85 @@
 import * as path from 'path'
 import * as fs from 'fs'
-import pino from 'pino'
+
+type PinoDestinationStream = {
+  write: (chunk: any) => void
+  flush?: () => void
+  end?: () => void
+}
+
+type LoggerLike = {
+  debug: (data: any) => void
+  info: (data: any) => void
+  warn: (data: any) => void
+  error: (data: any) => void
+}
+
+type PinoModule = {
+  (options?: any, destination?: any): LoggerLike
+  destination: (options?: any) => PinoDestinationStream
+  multistream: (streams: Array<{ level?: string, stream: PinoDestinationStream }>) => any
+  transport?: (options: any) => PinoDestinationStream
+  stdTimeFunctions?: { isoTime: () => string }
+}
+
+function formatForConsole(data: any): string {
+  if (typeof data === 'string') {
+    return data
+  }
+
+  try {
+    return JSON.stringify(data)
+  } catch (error) {
+    return String(data)
+  }
+}
+
+function createConsoleDestination(): PinoDestinationStream {
+  return {
+    write(chunk: any) {
+      const output = formatForConsole(chunk)
+      // eslint-disable-next-line no-console
+      console.log(output)
+    }
+  }
+}
+
+function createConsoleLogger(): LoggerLike {
+  return {
+    debug(data: any) {
+      // eslint-disable-next-line no-console
+      console.debug(formatForConsole(data))
+    },
+    info(data: any) {
+      // eslint-disable-next-line no-console
+      console.info(formatForConsole(data))
+    },
+    warn(data: any) {
+      // eslint-disable-next-line no-console
+      console.warn(formatForConsole(data))
+    },
+    error(data: any) {
+      // eslint-disable-next-line no-console
+      console.error(formatForConsole(data))
+    }
+  }
+}
+
+function loadPinoModule(): PinoModule | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
+    return require('pino') as PinoModule
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn('pino module not found, using console-based logger fallback.', {
+      error: error instanceof Error ? error.message : String(error)
+    })
+    return null
+  }
+}
+
+const pinoModule = loadPinoModule()
+const fallbackDestination = createConsoleDestination()
 
 // Sensitive data patterns to sanitize
 const SENSITIVE_PATTERNS = [
@@ -107,31 +186,83 @@ const baseConfig = {
   env: process.env.NODE_ENV || 'development'
 }
 
+const prettyPrintOptions = {
+  colorize: true,
+  translateTime: 'SYS:standard',
+  singleLine: false,
+  messageKey: 'msg',
+  ignore: 'service,env,event,ctx,err,corr_id,duration_ms,status,route,user_id'
+} as const
+
+function createPrettyStream(): PinoDestinationStream | null {
+  if (!pinoModule || !isDev || isTest) {
+    return null
+  }
+
+  try {
+    const transport = pinoModule.transport?.({
+      target: 'pino-pretty',
+      options: prettyPrintOptions
+    })
+    if (transport) {
+      return transport as unknown as PinoDestinationStream
+    }
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn('Pretty logging transport unavailable, falling back to stdout.', {
+      error: error instanceof Error ? error.message : String(error)
+    })
+  }
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const pretty = require('pino-pretty')
+    if (typeof pretty === 'function') {
+      return pretty(prettyPrintOptions)
+    }
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn('pino-pretty could not be loaded. Continuing without pretty logging.', {
+      error: error instanceof Error ? error.message : String(error)
+    })
+  }
+
+  return null
+}
+
 // Create rotating file streams
-function createRotatingStream(logDir: string, filename: string) {
-  if (!fileLoggingEnabled) {
-    return pino.destination(1) // stdout fallback when filesystem is read-only
+function getStdoutDestination(): PinoDestinationStream {
+  if (pinoModule) {
+    return pinoModule.destination(1)
+  }
+
+  return fallbackDestination
+}
+
+function createRotatingStream(logDir: string, filename: string): PinoDestinationStream {
+  if (!pinoModule || !fileLoggingEnabled) {
+    return getStdoutDestination() // stdout fallback when filesystem is read-only or pino missing
   }
 
   const today = new Date().toISOString().split('T')[0] // YYYY-MM-DD
   const filePath = path.join(logDir, `${filename}-${today}.log`)
 
-  return pino.destination({
+  return pinoModule.destination({
     dest: filePath,
     sync: false
   })
 }
 
 // Create main logger with file transports
-const logger = pino({
+const logger: LoggerLike = pinoModule ? pinoModule({
   level: process.env.LOG_LEVEL || (isDev ? 'debug' : 'info'),
   base: baseConfig,
-  timestamp: pino.stdTimeFunctions.isoTime,
+  timestamp: pinoModule.stdTimeFunctions?.isoTime ?? (() => new Date().toISOString()),
   formatters: {
     level(label: string) { return { level: label } }
   }
-}, pino.multistream((() => {
-  const streams = [] as Array<{ level?: string, stream: pino.DestinationStream }>
+}, pinoModule.multistream((() => {
+  const streams: Array<{ level?: string, stream: PinoDestinationStream }> = []
 
   if (fileLoggingEnabled) {
     streams.push({
@@ -143,27 +274,19 @@ const logger = pino({
     })
   }
 
-  if (isDev && !isTest) {
+  const prettyStream = createPrettyStream()
+  if (prettyStream) {
     streams.push({
-      stream: pino.transport({
-        target: 'pino-pretty',
-        options: {
-          colorize: true,
-          translateTime: 'SYS:standard',
-          singleLine: false,
-          messageKey: 'msg',
-          ignore: 'service,env,event,ctx,err,corr_id,duration_ms,status,route,user_id'
-        }
-      })
+      stream: prettyStream
     })
   }
 
   if (streams.length === 0) {
-    streams.push({ stream: pino.destination(1) })
+    streams.push({ stream: getStdoutDestination() })
   }
 
   return streams
-})()))
+})())) : createConsoleLogger()
 
 // Note: We use the main logger with daily rotation instead of separate file loggers
 // to avoid creating empty files and duplicate logging

--- a/test/types/shims.d.ts
+++ b/test/types/shims.d.ts
@@ -37,6 +37,12 @@ declare module 'module' {
   export = Module
 }
 
+declare module 'pino' {
+  export type DestinationStream = any
+  const pino: any
+  export default pino
+}
+
 declare function require(moduleName: string): any
 
 declare module 'next/server' {


### PR DESCRIPTION
## Summary
- load `pino` dynamically and fall back to console logging when the dependency or pretty transport cannot be resolved
- provide graceful stdout fallbacks for rotating streams and pretty output so translation continues to work even without `pino`
- stub `pino` in test shims so the test TypeScript build can resolve the module when it is absent at runtime

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1287ed8b483298fa2d52d2168a58b