### PR TITLE
Stabilize dictionary fallback and default experience on modern Librán

### DIFF
--- a/app/components/PhrasePicker.tsx
+++ b/app/components/PhrasePicker.tsx
@@ -14,6 +14,7 @@ export default function PhrasePicker({ onPhraseSelect, onLoadingChange }: Phrase
   const [loading, setLoading] = useState(true)
   const [searchTerm, setSearchTerm] = useState('')
   const [selectedCategory, setSelectedCategory] = useState<string>('all')
+  const isAncientDisabled = true
 
   useEffect(() => {
     loadPhrases()
@@ -133,8 +134,16 @@ export default function PhrasePicker({ onPhraseSelect, onLoadingChange }: Phrase
               
               <div className="flex space-x-2">
                 <button
-                  onClick={() => onPhraseSelect(phrase, 'ancient')}
-                  className="flex-1 px-2 py-1 bg-libran-gold/20 border border-libran-gold/30 rounded text-xs text-libran-gold hover:bg-libran-gold/30 transition-colors"
+                  onClick={() => {
+                    if (isAncientDisabled) return
+                    onPhraseSelect(phrase, 'ancient')
+                  }}
+                  disabled={isAncientDisabled}
+                  className={`flex-1 px-2 py-1 border rounded text-xs transition-colors ${
+                    isAncientDisabled
+                      ? 'bg-libran-gold/10 border-libran-gold/20 text-libran-gold/50 cursor-not-allowed'
+                      : 'bg-libran-gold/20 border-libran-gold/30 text-libran-gold hover:bg-libran-gold/30'
+                  }`}
                 >
                   Ancient: {phrase.ancient}
                 </button>
@@ -160,6 +169,12 @@ export default function PhrasePicker({ onPhraseSelect, onLoadingChange }: Phrase
           <p className="text-sm text-gray-400">No phrases found</p>
           <p className="text-xs text-gray-500 mt-1">Try adjusting your search or filter</p>
         </div>
+      )}
+
+      {isAncientDisabled && (
+        <p className="text-xs text-gray-500">
+          Ancient phrase presets are temporarily disabled while we focus on the modern Librán library.
+        </p>
       )}
     </div>
   )

--- a/app/components/TranslationResult.tsx
+++ b/app/components/TranslationResult.tsx
@@ -10,17 +10,21 @@ interface TranslationResultProps {
   confidence?: number
   wordCount?: number
   isTranslating?: boolean
+  requestedVariant?: 'ancient' | 'modern'
 }
 
-export default function TranslationResult({ 
-  libranText, 
-  variant, 
-  originalText, 
-  confidence, 
+export default function TranslationResult({
+  libranText,
+  variant,
+  originalText,
+  confidence,
   wordCount,
-  isTranslating = false
+  isTranslating = false,
+  requestedVariant
 }: TranslationResultProps) {
   const [copied, setCopied] = useState(false)
+
+  const showFallbackNotice = requestedVariant && requestedVariant !== variant
 
   const handleCopy = async () => {
     try {
@@ -89,6 +93,12 @@ export default function TranslationResult({
             {libranText}
           </div>
         </div>
+
+        {showFallbackNotice && (
+          <div className="text-xs text-amber-300 bg-amber-500/10 border border-amber-500/30 rounded-md px-3 py-2">
+            Ancient Librán is temporarily served by the modern dictionary. Results reflect the modern variant.
+          </div>
+        )}
 
         {originalText && (
           <div className="text-sm text-gray-400">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,7 +19,7 @@ import type { Phrase } from '../lib/types/phrase'
 
 export default function Home() {
   const [inputText, setInputText] = useState('')
-  const [variant, setVariant] = useState<'ancient' | 'modern'>('ancient')       
+  const [variant, setVariant] = useState<'ancient' | 'modern'>('modern')
   const [libranText, setLibranText] = useState('')
   const [selectedVoice, setSelectedVoice] = useState<VoiceProfile | null>(null) 
   const [selectedVoiceFilter, setSelectedVoiceFilter] = useState<VoiceFilter | null>(null)                                                                      
@@ -32,6 +32,7 @@ export default function Home() {
   const [translationData, setTranslationData] = useState<{
     confidence?: number
     wordCount?: number
+    requestedVariant?: 'ancient' | 'modern'
   }>({})
   const [showVoiceSelector, setShowVoiceSelector] = useState(false)
   const [ttsProviderInfo, setTtsProviderInfo] = useState<{
@@ -40,7 +41,7 @@ export default function Home() {
     fallback: boolean
   } | null>(null)
 
-  const handleTranslation = (translatedText: string, selectedVariant: 'ancient' | 'modern', originalText: string, translationData?: { confidence?: number, wordCount?: number }) => {                                                           
+  const handleTranslation = (translatedText: string, selectedVariant: 'ancient' | 'modern', originalText: string, translationData?: { confidence?: number, wordCount?: number, requestedVariant?: 'ancient' | 'modern' }) => {
     setLibranText(translatedText)
     setVariant(selectedVariant)
     setInputText(originalText)
@@ -55,8 +56,9 @@ export default function Home() {
     setInputText(phrase.english)
     setVariant(selectedVariant)
     setTranslationData({
-      confidence: 1.0, // Phrases are pre-translated, so 100% confidence        
-      wordCount: phrase.english.split(' ').length
+      confidence: 1.0, // Phrases are pre-translated, so 100% confidence
+      wordCount: phrase.english.split(' ').length,
+      requestedVariant: selectedVariant
     })
   }
 
@@ -250,6 +252,7 @@ export default function Home() {
                 originalText={inputText}
                 confidence={translationData.confidence}
                 wordCount={translationData.wordCount}
+                requestedVariant={translationData.requestedVariant}
                 isTranslating={isTranslating}
               />
 

--- a/lib/translator/dictionary-loader.ts
+++ b/lib/translator/dictionary-loader.ts
@@ -2,6 +2,8 @@ import * as fs from 'fs'
 import path from 'path'
 import { watch } from 'fs'
 
+import modernDictionaryFile from './dictionaries/modern.json'
+
 export interface DictionaryEntry {
   [key: string]: string | {
     base?: string
@@ -14,6 +16,7 @@ export interface DictionaryEntry {
 }
 
 export interface Dictionary {
+  variant: 'ancient' | 'modern'
   version?: string
   language?: string
   metadata?: {
@@ -28,6 +31,13 @@ export interface Dictionary {
   }
 }
 
+type RawDictionaryObject = Omit<Dictionary, 'variant'>
+type RawDictionaryFile = RawDictionaryObject | DictionaryEntry
+
+const staticDictionaryFiles: Partial<Record<'ancient' | 'modern', RawDictionaryFile>> = {
+  modern: modernDictionaryFile as RawDictionaryFile
+}
+
 const dictionaryCache = new Map<string, Dictionary>()
 let fileWatchers: Map<string, any> = new Map()
 let isWatching = false
@@ -39,41 +49,61 @@ export async function loadDictionary(variant: 'ancient' | 'modern'): Promise<Dic
   }
 
   try {
-    // Use process.cwd() for path resolution in both dev and test environments
-    const dictionaryPath = path.join(process.cwd(), 'lib', 'translator', 'dictionaries', `${variant}.json`)
-    const dictionaryData = fs.readFileSync(dictionaryPath, 'utf-8')
-    const rawDictionary = JSON.parse(dictionaryData)
-    
-    // Convert simple key-value format to Dictionary interface
-    const dictionary: Dictionary = {
-      version: '1.0.0',
-      language: `${variant}-libran`,
-      metadata: {
-        description: `${variant} Librán dictionary`,
-        lastUpdated: new Date().toISOString(),
-        wordCount: Object.keys(rawDictionary).length
-      },
-      entries: rawDictionary,
-      rules: {}
-    }
-    
+    const dictionary = loadDictionaryFromFileSystem(variant)
+
     // Cache the dictionary
     dictionaryCache.set(variant, dictionary)
-    
+
     // Start watching the file for changes (only in development)
     if (process.env.NODE_ENV === 'development' && !isWatching) {
       startFileWatching()
     }
-    
+
     return dictionary
   } catch (error) {
-    console.error(`Failed to load ${variant} dictionary:`, error)
-    throw new Error(`Dictionary not found: ${variant}.json`)
+    const fallbackVariant = resolveFallbackVariant(variant)
+
+    if (!fallbackVariant) {
+      throw error
+    }
+
+    console.warn(
+      `[DictionaryLoader] Falling back to bundled dictionary for ${variant} variant using ${fallbackVariant} data`,
+      error instanceof Error ? error.message : error
+    )
+
+    try {
+      if (fallbackVariant !== variant) {
+        const fallbackFromFile = loadDictionaryFromFileSystem(fallbackVariant)
+        dictionaryCache.set(variant, fallbackFromFile)
+        dictionaryCache.set(fallbackVariant, fallbackFromFile)
+        return fallbackFromFile
+      }
+    } catch (fallbackError) {
+      console.warn(
+        `[DictionaryLoader] Failed to load fallback dictionary from filesystem for ${fallbackVariant}:`,
+        fallbackError instanceof Error ? fallbackError.message : fallbackError
+      )
+    }
+
+    const fallbackDictionaryFile = staticDictionaryFiles[fallbackVariant]
+
+    if (!fallbackDictionaryFile) {
+      throw new Error(`Fallback dictionary not available for variant ${fallbackVariant}`)
+    }
+
+    const bundledDictionary = normalizeDictionary(fallbackVariant, fallbackDictionaryFile)
+    dictionaryCache.set(variant, bundledDictionary)
+    if (fallbackVariant !== variant) {
+      dictionaryCache.set(fallbackVariant, bundledDictionary)
+    }
+
+    return bundledDictionary
   }
 }
 
 export function getDictionaryEntry(
-  dictionary: Dictionary, 
+  dictionary: Dictionary,
   word: string
 ): string | undefined {
   const lowerWord = word.toLowerCase()
@@ -100,10 +130,10 @@ export function getDictionaryRules(dictionary: Dictionary): Record<string, any> 
 // File watching and cache management functions
 function startFileWatching() {
   if (isWatching) return
-  
+
   isWatching = true
   const dictionariesDir = path.join(process.cwd(), 'lib', 'translator', 'dictionaries')
-  
+
   console.log('[DictionaryLoader] Starting file watching for hot-reload in development mode')
   
   // Watch for changes to dictionary files
@@ -112,6 +142,121 @@ function startFileWatching() {
   variants.forEach(variant => {
     setupFileWatcher(variant, dictionariesDir)
   })
+}
+
+function loadDictionaryFromFileSystem(variant: 'ancient' | 'modern'): Dictionary {
+  const { path: dictionaryPath, resolvedVariant } = resolveDictionaryPath(variant)
+  const dictionaryData = fs.readFileSync(dictionaryPath, 'utf-8')
+  const rawDictionary = JSON.parse(dictionaryData) as RawDictionaryFile
+
+  return normalizeDictionary(resolvedVariant, rawDictionary)
+}
+
+function normalizeDictionary(variant: 'ancient' | 'modern', rawDictionary: RawDictionaryFile): Dictionary {
+  if (!rawDictionary || typeof rawDictionary !== 'object') {
+    throw new Error(`Invalid dictionary format for ${variant}`)
+  }
+
+  if (hasEntriesObject(rawDictionary)) {
+    const entries = normalizeEntries(rawDictionary.entries)
+    const phrases = rawDictionary.phrases ? normalizeEntries(rawDictionary.phrases) : undefined
+    const metadata = normalizeMetadata(variant, rawDictionary.metadata, entries)
+
+    return {
+      variant,
+      version: rawDictionary.version ?? '1.0.0',
+      language: rawDictionary.language ?? `${variant}-libran`,
+      metadata,
+      entries,
+      phrases,
+      rules: rawDictionary.rules ?? {}
+    }
+  }
+
+  const entries = normalizeEntries(rawDictionary as DictionaryEntry)
+
+  return {
+    variant,
+    version: '1.0.0',
+    language: `${variant}-libran`,
+    metadata: normalizeMetadata(variant, undefined, entries),
+    entries,
+    rules: {}
+  }
+}
+
+function hasEntriesObject(value: RawDictionaryFile): value is RawDictionaryObject {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'entries' in value &&
+    typeof (value as RawDictionaryObject).entries === 'object'
+  )
+}
+
+function normalizeMetadata(
+  variant: 'ancient' | 'modern',
+  metadata: Dictionary['metadata'] | undefined,
+  entries: DictionaryEntry
+): NonNullable<Dictionary['metadata']> {
+  const wordCount = Object.keys(entries).length
+
+  if (metadata) {
+    return {
+      description: metadata.description ?? `${variant} Librán dictionary`,
+      lastUpdated: metadata.lastUpdated ?? new Date().toISOString(),
+      wordCount: metadata.wordCount ?? wordCount
+    }
+  }
+
+  return {
+    description: `${variant} Librán dictionary`,
+    lastUpdated: new Date().toISOString(),
+    wordCount
+  }
+}
+
+function normalizeEntries(entries: DictionaryEntry): DictionaryEntry {
+  return Object.entries(entries).reduce<DictionaryEntry>((acc, [key, value]) => {
+    const normalizedKey = key.toLowerCase()
+    acc[normalizedKey] = value
+    return acc
+  }, {})
+}
+
+function resolveDictionaryPath(variant: 'ancient' | 'modern'): { path: string, resolvedVariant: 'ancient' | 'modern' } {
+  const candidateVariants: Array<'ancient' | 'modern'> = [variant]
+
+  const attemptedPaths: string[] = []
+
+  for (const candidateVariant of candidateVariants) {
+    const candidatePaths = [
+      path.join(process.cwd(), 'lib', 'translator', 'dictionaries', `${candidateVariant}.json`),
+      path.join(__dirname, 'dictionaries', `${candidateVariant}.json`),
+      path.join(process.cwd(), '.next', 'server', 'app', 'lib', 'translator', 'dictionaries', `${candidateVariant}.json`)
+    ]
+
+    for (const candidatePath of candidatePaths) {
+      attemptedPaths.push(candidatePath)
+      if (fs.existsSync(candidatePath)) {
+        return { path: candidatePath, resolvedVariant: candidateVariant }
+      }
+    }
+  }
+
+  throw new Error(`Dictionary file not found for ${variant}. Checked paths: ${attemptedPaths.join(', ')}`)
+}
+
+function resolveFallbackVariant(variant: 'ancient' | 'modern'): 'ancient' | 'modern' | undefined {
+  if (variant === 'modern') {
+    return 'modern'
+  }
+
+  if (variant === 'ancient') {
+    return 'modern'
+  }
+
+  return undefined
 }
 
 function setupFileWatcher(variant: 'ancient' | 'modern', dictionariesDir: string) {


### PR DESCRIPTION
## Summary
- track the active variant on loaded dictionaries, normalize entry casing, and fall back to the modern corpus (preferring on-disk data when available)
- propagate the effective dictionary variant through the translator and API so logs, metrics, and clients know when a fallback occurred
- pivot the client experience to modern Librán by default, disabling ancient inputs, surfacing fallback messaging, and updating preset phrase actions

## Testing
- npm run lint *(fails: Failed to load config "prettier" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_68d550516f4083298125f0f860d6f61d