### PR TITLE
fix: stabilize Vitest mocks and hero scroll indicator

### DIFF
--- a/app/hero/page.tsx
+++ b/app/hero/page.tsx
@@ -344,6 +344,7 @@ export default function HeroPage() {
                     style={{ fontFamily: 'Cinzel, serif', letterSpacing: '0.1em' }}
                     whileHover={{ scale: 1.05 }}
                     whileTap={{ scale: 0.95 }}
+                    type="button"
                     onClick={() => window.location.href = '/app'}
                   >
                     <Play className="mr-3" size={24} />
@@ -358,6 +359,7 @@ export default function HeroPage() {
                         onClick={() => setCurrentScene(index)}
                         whileHover={{ scale: 1.2 }}
                         whileTap={{ scale: 0.8 }}
+                        type="button"
                       />
                     ))}
                   </div>
@@ -426,6 +428,7 @@ export default function HeroPage() {
               <ChevronRight
                 size={24}
                 className="text-blue-400/70 rotate-90"
+                data-testid="chevron-right-icon"
               />
             </motion.div>
           </motion.div>

--- a/test/vitest/hero-page.test.tsx
+++ b/test/vitest/hero-page.test.tsx
@@ -3,17 +3,23 @@ import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import HeroPage from '../../app/hero/page'
 
-// Mock framer-motion
-vi.mock('framer-motion', () => ({
-  motion: {
-    div: ({ children, ...props }: any) => <div {...props}>{children}</div>,
-    h1: ({ children, ...props }: any) => <h1 {...props}>{children}</h1>,
-    h2: ({ children, ...props }: any) => <h2 {...props}>{children}</h2>,
-    p: ({ children, ...props }: any) => <p {...props}>{children}</p>,
-    button: ({ children, ...props }: any) => <button {...props}>{children}</button>
-  },
-  AnimatePresence: ({ children }: any) => children
-}))
+// Mock framer-motion so any motion.* call renders the corresponding HTML element
+vi.mock('framer-motion', () => {
+  const createComponent = (tag: string) => ({ children, ...props }: any) =>
+    React.createElement(tag, props, children)
+
+  const motionProxy = new Proxy(
+    {},
+    {
+      get: (_target, key: string) => createComponent(key)
+    }
+  )
+
+  return {
+    motion: motionProxy,
+    AnimatePresence: ({ children }: any) => <>{children}</>
+  }
+})
 
 // Mock lucide-react icons
 vi.mock('lucide-react', () => ({


### PR DESCRIPTION
## Summary
- mock framer-motion with a proxy in the Vitest suites so motion components resolve to intrinsic elements
- align the simple voice system test double with the production API to stop runtime errors in AppPage tests
- add button types and a test id to the hero scroll indicator icon for deterministic queries

## Testing
- npm run test:coverage *(fails: rollup optional dependency @rollup/rollup-linux-x64-gnu missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d704f68d508329b44c1a3e21a2e09e